### PR TITLE
feat(theme): Hermes 多主题系统 + 主题选择器

### DIFF
--- a/_data/themes.yml
+++ b/_data/themes.yml
@@ -1,0 +1,54 @@
+# Visual themes ported from hermes-agent (web/src/themes/presets.ts).
+# `swatch` = [background, midground, accent] colors shown in the picker.
+# `font`   = Google Fonts URL injected when the theme is active (optional).
+# Keys here must match the `data-theme` values in _sass/themes/_hermes.scss.
+
+- id: hermes
+  label: Hermes Teal
+  desc: 经典深青色 — 标志性的 Hermes 外观
+  swatch: ["#041c1c", "#ffe6cb", "#34d399"]
+
+- id: hermes-large
+  label: Hermes Teal (Large)
+  desc: 更大的字号与更宽松的间距
+  swatch: ["#041c1c", "#ffe6cb", "#34d399"]
+
+- id: nous-blue
+  label: Nous Blue
+  desc: 浅色模式 — 米色画布上的 Nous 蓝
+  swatch: ["#e8f2fd", "#0053fd", "#001934"]
+
+- id: midnight
+  label: Midnight
+  desc: 深蓝紫色，冷色调点缀
+  swatch: ["#0a0a1f", "#d4c8ff", "#a78bfa"]
+  font: https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap
+
+- id: ember
+  label: Ember
+  desc: 暖红与古铜 — 熔炉气息
+  swatch: ["#1a0a06", "#ffd8b0", "#f97316"]
+  font: https://fonts.googleapis.com/css2?family=Spectral:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;700&display=swap
+
+- id: mono
+  label: Mono
+  desc: 纯净灰阶 — 极简专注
+  swatch: ["#0e0e0e", "#eaeaea", "#bdbdbd"]
+  font: https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap
+
+- id: cyberpunk
+  label: Cyberpunk
+  desc: 黑底霓虹绿 — 矩阵终端
+  swatch: ["#040608", "#9bffcf", "#00ff88"]
+  font: https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=JetBrains+Mono:wght@400;700&display=swap
+
+- id: rose
+  label: Rosé
+  desc: 柔和粉色与暖象牙白 — 护眼
+  swatch: ["#1a0f15", "#ffd4e1", "#f9a8d4"]
+  font: https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=DM+Mono:wght@400;500&display=swap
+
+- id: classic
+  label: Classic
+  desc: 原始 Chirpy 浅色/深色主题
+  swatch: ["#1b1b1e", "#afb0b1", "#8ab4f8"]

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,104 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+  <!-- Visual theme picker (Hermes default). Early apply avoids FOUC; the
+       drop-up menu, persistence and per-theme web-font injection are wired
+       on DOMContentLoaded. -->
+  <script>
+    (function () {
+      var KEY = 'site-theme';
+      var DEFAULT = 'hermes';
+
+      function apply(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        try { localStorage.setItem(KEY, theme); } catch (e) { /* ignore */ }
+      }
+
+      function injectFont(url) {
+        var link = document.getElementById('theme-font');
+        if (!url) { if (link) { link.remove(); } return; }
+        if (!link) {
+          link = document.createElement('link');
+          link.id = 'theme-font';
+          link.rel = 'stylesheet';
+          document.head.appendChild(link);
+        }
+        if (link.getAttribute('href') !== url) { link.setAttribute('href', url); }
+      }
+
+      /* Early apply — runs before paint. */
+      try { apply(localStorage.getItem(KEY) || DEFAULT); } catch (e) { apply(DEFAULT); }
+
+      document.addEventListener('DOMContentLoaded', function () {
+        var picker = document.getElementById('theme-picker');
+        var trigger = document.getElementById('theme-switch');
+        var menu = document.getElementById('theme-menu');
+        if (!picker || !trigger || !menu) { return; }
+        var options = menu.querySelectorAll('.theme-option');
+
+        function current() {
+          return document.documentElement.getAttribute('data-theme') || DEFAULT;
+        }
+
+        function sync() {
+          var cur = current();
+          for (var i = 0; i < options.length; i++) {
+            var on = options[i].getAttribute('data-theme-id') === cur;
+            options[i].setAttribute('aria-selected', on ? 'true' : 'false');
+            if (on) { injectFont(options[i].getAttribute('data-font')); }
+          }
+        }
+
+        function position() {
+          var r = trigger.getBoundingClientRect();
+          var gap = 8;
+          /* Align the menu's left edge to the trigger, clamped to the
+             viewport, and float it just above the trigger. */
+          var left = Math.min(r.left, window.innerWidth - menu.offsetWidth - 8);
+          menu.style.left = Math.max(8, left) + 'px';
+          menu.style.bottom = (window.innerHeight - r.top + gap) + 'px';
+        }
+
+        function close() {
+          menu.hidden = true;
+          trigger.setAttribute('aria-expanded', 'false');
+        }
+
+        function toggle() {
+          if (menu.hidden) {
+            menu.hidden = false;
+            position();
+            trigger.setAttribute('aria-expanded', 'true');
+          } else {
+            close();
+          }
+        }
+
+        sync();
+
+        trigger.addEventListener('click', function (e) {
+          e.stopPropagation();
+          toggle();
+        });
+
+        for (var i = 0; i < options.length; i++) {
+          options[i].addEventListener('click', function () {
+            apply(this.getAttribute('data-theme-id'));
+            sync();
+            close();
+          });
+        }
+
+        document.addEventListener('click', function (e) {
+          if (!picker.contains(e.target)) { close(); }
+        });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') { close(); }
+        });
+      });
+    })();
+  </script>
+
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f7f7">
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e">
   <meta name="mobile-web-app-capable" content="yes">

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -41,12 +41,6 @@
   </nav>
 
   <div class="sidebar-bottom d-flex flex-wrap  align-items-center w-100">
-    {% unless site.theme_mode %}
-      <button type="button" class="btn btn-link nav-link" aria-label="Switch Mode" id="mode-toggle">
-        <i class="fas fa-adjust"></i>
-      </button>
-    {% endunless %}
-
     {% include theme-picker.html lang=lang %}
 
     {% if site.data.contact.size > 0 %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -45,11 +45,13 @@
       <button type="button" class="btn btn-link nav-link" aria-label="Switch Mode" id="mode-toggle">
         <i class="fas fa-adjust"></i>
       </button>
-
-      {% if site.data.contact.size > 0 %}
-        <span class="icon-border"></span>
-      {% endif %}
     {% endunless %}
+
+    {% include theme-picker.html lang=lang %}
+
+    {% if site.data.contact.size > 0 %}
+      <span class="icon-border"></span>
+    {% endif %}
 
     {% for entry in site.data.contact %}
       {%- assign url = null -%}

--- a/_includes/theme-picker.html
+++ b/_includes/theme-picker.html
@@ -1,0 +1,38 @@
+<!-- Theme picker — palette trigger + drop-up menu listing all themes.
+     Selection/persistence/font-injection handled by the inline script in
+     head.html. -->
+<div class="theme-picker" id="theme-picker">
+  <button
+    type="button"
+    class="btn btn-link nav-link"
+    id="theme-switch"
+    aria-label="Switch Theme"
+    aria-haspopup="listbox"
+    aria-expanded="false"
+  >
+    <i class="fas fa-palette"></i>
+  </button>
+
+  <div class="theme-menu" id="theme-menu" role="listbox" tabindex="-1" hidden>
+    <p class="theme-menu-title">{{ site.data.locales[include.lang].theme | default: '主题' }}</p>
+    {% for th in site.data.themes %}
+      <button
+        type="button"
+        class="theme-option"
+        role="option"
+        aria-selected="false"
+        data-theme-id="{{ th.id }}"
+        {% if th.font %}data-font="{{ th.font }}"{% endif %}
+      >
+        <span class="theme-swatch" aria-hidden="true">
+          {% for c in th.swatch %}<span style="background-color: {{ c }}"></span>{% endfor %}
+        </span>
+        <span class="theme-option-text">
+          <span class="theme-option-label">{{ th.label }}</span>
+          <span class="theme-option-desc">{{ th.desc }}</span>
+        </span>
+        <i class="fas fa-check theme-check" aria-hidden="true"></i>
+      </button>
+    {% endfor %}
+  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@ layout: compress
 {% endif %}
 
 <!-- `site.alt_lang` can specify a language different from the UI -->
-<html lang="{{ page.lang | default: site.alt_lang | default: site.lang }}" {{ prefer_mode }}>
+<html lang="{{ page.lang | default: site.alt_lang | default: site.lang }}" data-theme="hermes" {{ prefer_mode }}>
   {% include head.html lang=lang %}
 
   <body>

--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -131,6 +131,23 @@ layout: page
     }
   }
 
+  /* Hermes themes win over the light/dark defaults above: derive every
+     project-card surface from the active palette so the cards match the
+     theme instead of staying ivory/black-gold. Works for both the dark
+     presets and the light `nous-blue` (all reference the same vars). */
+  html[data-theme]:not([data-theme='classic']) #page-projects {
+    --pj-card-bg:        var(--card-bg);
+    --pj-icon-bg:        linear-gradient(180deg, rgb(255 255 255 / 8%) 0%, rgb(255 255 255 / 3%) 100%);
+    --pj-arrow:          var(--text-muted-color);
+    --pj-arrow-hover:    var(--link-color);
+    --pj-shadow:         rgb(0 0 0 / 40%);
+    --pj-shadow-hover:   rgb(0 0 0 / 60%);
+    --pj-shine:          var(--hermes-line-strong);
+    --pj-inner-top:      var(--hermes-line);
+    --pj-inner-top-hover: var(--hermes-line-strong);
+    --pj-glow-hover:     var(--tag-hover);
+  }
+
   /* Tabs */
   .project-tabs {
     display: inline-flex;
@@ -423,6 +440,10 @@ layout: page
     html:not([data-mode='light']) .pj-status.is-wip  { color: var(--pj-gold-warm); }
     html:not([data-mode='light']) .pj-status.is-archived { color: #c0c0c5; }
   }
+  /* Brighter pill text on the dark Hermes presets (nous-blue stays light). */
+  html[data-theme]:not([data-theme='classic']):not([data-theme='nous-blue']) .pj-status.is-live { color: #62d685; }
+  html[data-theme]:not([data-theme='classic']):not([data-theme='nous-blue']) .pj-status.is-wip  { color: var(--pj-gold-warm); }
+  html[data-theme]:not([data-theme='classic']):not([data-theme='nous-blue']) .pj-status.is-archived { color: #c0c0c5; }
 
   /* Arrow */
   .project-row-arrow {

--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -4,6 +4,7 @@
 @use '../abstracts/placeholders';
 @use '../themes/light';
 @use '../themes/dark';
+@use '../themes/hermes';
 
 :root {
   font-size: 16px;
@@ -36,6 +37,10 @@ html {
     overflow-y: scroll;
   }
 }
+
+/* Hermes themes — emit every preset's vars + shared chrome, after the
+   light/dark blocks so an active theme wins the cascade. */
+@include hermes.emit;
 
 body {
   background: var(--main-bg);

--- a/_sass/components/_index.scss
+++ b/_sass/components/_index.scss
@@ -1,2 +1,3 @@
 @forward 'buttons';
 @forward 'popups';
+@forward 'theme-picker';

--- a/_sass/components/_theme-picker.scss
+++ b/_sass/components/_theme-picker.scss
@@ -1,0 +1,107 @@
+/* Theme picker — drop-up menu in the sidebar rail. Theme-agnostic: built
+   from Chirpy CSS variables so it adapts to whichever theme is active
+   (including `classic`). */
+
+.theme-picker {
+  position: relative;
+  display: inline-flex;
+}
+
+.theme-menu {
+  /* Fixed so the sidebar's `overflow-y: auto` can't clip it. Exact
+     left/bottom are set inline by the picker script on open. */
+  position: fixed;
+  z-index: 1051;
+  width: 16rem;
+  max-width: calc(100vw - 1rem);
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: 0.4rem;
+  border: 1px solid var(--main-border-color);
+  border-radius: 0.5rem;
+  background-color: var(--card-bg);
+  box-shadow: var(--card-shadow);
+
+  &[hidden] {
+    display: none;
+  }
+
+  .theme-menu-title {
+    margin: 0.25rem 0.5rem 0.5rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted-color);
+  }
+}
+
+.theme-option {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  padding: 0.5rem 0.55rem;
+  border: 0;
+  border-radius: 0.4rem;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: var(--text-color);
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: var(--sidebar-hover-bg);
+  }
+
+  &[aria-selected='true'] {
+    background-color: var(--sidebar-hover-bg);
+
+    .theme-check {
+      opacity: 1;
+    }
+  }
+}
+
+.theme-swatch {
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: 2.6rem;
+  height: 1.5rem;
+  overflow: hidden;
+  border-radius: 0.25rem;
+  border: 1px solid var(--main-border-color);
+
+  span {
+    flex: 1 1 0;
+  }
+}
+
+.theme-option-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.theme-option-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--heading-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.theme-option-desc {
+  font-size: 0.7rem;
+  line-height: 1.3;
+  color: var(--text-muted-color);
+}
+
+.theme-check {
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  color: var(--hermes-teal, var(--link-color));
+  opacity: 0;
+}

--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -225,19 +225,10 @@ $sidebar-display: 'sidebar-display'; /* the attribute for sidebar display */
       line-height: $btn-size;
     }
 
-    #mode-toggle,
     #theme-switch {
       @extend %button;
       @extend %sidebar-links;
       @extend %sidebar-link-hover;
-    }
-
-    #mode-toggle {
-      margin-right: v.$sb-btn-gap;
-
-      @include bp.xxxl {
-        margin-right: v.$sb-btn-gap-lg;
-      }
     }
 
     .icon-border {

--- a/_sass/layout/_sidebar.scss
+++ b/_sass/layout/_sidebar.scss
@@ -225,10 +225,19 @@ $sidebar-display: 'sidebar-display'; /* the attribute for sidebar display */
       line-height: $btn-size;
     }
 
-    #mode-toggle {
+    #mode-toggle,
+    #theme-switch {
       @extend %button;
       @extend %sidebar-links;
       @extend %sidebar-link-hover;
+    }
+
+    #mode-toggle {
+      margin-right: v.$sb-btn-gap;
+
+      @include bp.xxxl {
+        margin-right: v.$sb-btn-gap-lg;
+      }
     }
 
     .icon-border {

--- a/_sass/themes/_hermes.scss
+++ b/_sass/themes/_hermes.scss
@@ -28,45 +28,45 @@ $chirpy-mono: ui-monospace, 'SF Mono', 'Cascadia Mono', menlo, consolas, monospa
 $themes: (
   'hermes': (
     bg: #041c1c, mid: #ffe6cb, accent: #34d399,
-    glow: rgba(255, 189, 56, 0.35), noise: 1, radius: 0.5rem,
+    glow: rgb(255 189 56 / 35%), noise: 1, radius: 0.5rem,
     base: 16px, lh: 1.6, light: false, font: null, mono: null
   ),
   'hermes-large': (
     bg: #041c1c, mid: #ffe6cb, accent: #34d399,
-    glow: rgba(255, 189, 56, 0.35), noise: 1, radius: 0.5rem,
+    glow: rgb(255 189 56 / 35%), noise: 1, radius: 0.5rem,
     base: 18px, lh: 1.7, light: false, font: null, mono: null
   ),
   'midnight': (
     bg: #0a0a1f, mid: #d4c8ff, accent: #a78bfa,
-    glow: rgba(167, 139, 250, 0.32), noise: 0.8, radius: 0.75rem,
+    glow: rgb(167 139 250 / 32%), noise: 0.8, radius: 0.75rem,
     base: 16px, lh: 1.6, light: false,
     font: ('Inter', 'Microsoft Yahei', sans-serif),
     mono: ('JetBrains Mono', monospace)
   ),
   'ember': (
     bg: #1a0a06, mid: #ffd8b0, accent: #f97316,
-    glow: rgba(249, 115, 22, 0.38), noise: 1, radius: 0.25rem,
+    glow: rgb(249 115 22 / 38%), noise: 1, radius: 0.25rem,
     base: 16px, lh: 1.6, light: false,
     font: ('Spectral', georgia, serif),
     mono: ('IBM Plex Mono', monospace)
   ),
   'mono': (
     bg: #0e0e0e, mid: #eaeaea, accent: #bdbdbd,
-    glow: rgba(255, 255, 255, 0.1), noise: 0.6, radius: 0,
+    glow: rgb(255 255 255 / 10%), noise: 0.6, radius: 0,
     base: 16px, lh: 1.6, light: false,
     font: ('IBM Plex Sans', 'Microsoft Yahei', sans-serif),
     mono: ('IBM Plex Mono', monospace)
   ),
   'cyberpunk': (
     bg: #040608, mid: #9bffcf, accent: #00ff88,
-    glow: rgba(0, 255, 136, 0.22), noise: 1.2, radius: 0,
+    glow: rgb(0 255 136 / 22%), noise: 1.2, radius: 0,
     base: 16px, lh: 1.6, light: false,
     font: ('Share Tech Mono', 'JetBrains Mono', monospace),
     mono: ('Share Tech Mono', monospace)
   ),
   'rose': (
     bg: #1a0f15, mid: #ffd4e1, accent: #f9a8d4,
-    glow: rgba(249, 168, 212, 0.3), noise: 0.9, radius: 1rem,
+    glow: rgb(249 168 212 / 30%), noise: 0.9, radius: 1rem,
     base: 16px, lh: 1.6, light: false,
     font: ('Fraunces', georgia, serif),
     mono: ('DM Mono', monospace)
@@ -76,7 +76,7 @@ $themes: (
      LENS_5I result. */
   'nous-blue': (
     bg: #e8f2fd, mid: #001934, accent: #0053fd,
-    glow: rgba(0, 83, 253, 0.1), noise: 0.25, radius: 0.5rem,
+    glow: rgb(0 83 253 / 10%), noise: 0.25, radius: 0.5rem,
     base: 16px, lh: 1.6, light: true, font: null, mono: null
   )
 );
@@ -99,11 +99,11 @@ $themes: (
   font-size: $base;
 
   /* Tinted surfaces derived from bg ± mid. */
-  $panel: if($light, color.mix(#fff, $bg, 55%), color.mix($mid, $bg, 7%));
-  $panel-2: if($light, color.mix(#fff, $bg, 30%), color.mix($mid, $bg, 11%));
+  $panel: if($light, color.mix(#ffffff, $bg, 55%), color.mix($mid, $bg, 7%));
+  $panel-2: if($light, color.mix(#ffffff, $bg, 30%), color.mix($mid, $bg, 11%));
   $panel-3: if($light, color.mix($mid, $bg, 6%), color.mix($mid, $bg, 16%));
-  $sink: if($light, color.mix($mid, $bg, 3%), color.mix(#000, $bg, 28%));
-  $code-bg: if($light, color.mix($mid, $bg, 5%), color.mix(#000, $bg, 45%));
+  $sink: if($light, color.mix($mid, $bg, 3%), color.mix(#000000, $bg, 28%));
+  $code-bg: if($light, color.mix($mid, $bg, 5%), color.mix(#000000, $bg, 45%));
 
   /* Secondary accents (syntax + callouts) — tuned for dark vs light canvas. */
   $blue: if($light, #0053fd, #6fb3ff);
@@ -126,10 +126,12 @@ $themes: (
   --glow-blend: #{if($light, multiply, lighten)};
   --theme-radius: #{$radius};
   --theme-lh: #{$lh};
-  @if $font != null {
+
+  @if $font {
     --theme-font-sans: #{$font};
   }
-  @if $mono != null {
+
+  @if $mono {
     --theme-font-mono: #{$mono};
   }
 
@@ -518,6 +520,7 @@ $themes: (
 
   /* Build the grouped selector for the shared chrome. */
   $sel: '';
+
   @each $name, $t in $themes {
     $piece: 'html[data-theme=#{$name}]';
     $sel: if($sel == '', $piece, '#{$sel}, #{$piece}');

--- a/_sass/themes/_hermes.scss
+++ b/_sass/themes/_hermes.scss
@@ -1,0 +1,529 @@
+/* ==========================================================================
+   Hermes themes — ported from hermes-agent (web/src/themes/presets.ts +
+   components/Backdrop.tsx + index.css).
+
+   Each preset is a dark (or, for `nous-blue`, light) palette built from four
+   core tokens — background / midground / accent / warm-glow — plus a noise
+   multiplier, corner radius and optional font stack. Every Chirpy CSS
+   variable is derived from those so a new theme is one row in `$themes`.
+
+   `emit` outputs:
+     • per-theme `html[data-theme='<name>']` blocks of CSS custom properties
+     • one grouped block of shared "chrome" (grain, vignette, tags, syntax,
+       radius, fonts) that reads those variables.
+
+   `classic` is intentionally absent → it falls through to stock Chirpy
+   light/dark.
+   ========================================================================== */
+
+@use 'sass:color';
+@use 'sass:map';
+
+/* Fallbacks so the default (Hermes) theme keeps Chirpy's native typography. */
+$chirpy-sans: 'Source Sans Pro', 'Microsoft Yahei', sans-serif;
+$chirpy-heading: lato, 'Microsoft Yahei', sans-serif;
+$chirpy-mono: ui-monospace, 'SF Mono', 'Cascadia Mono', menlo, consolas, monospace;
+
+/* name → palette/typography/layout. Mirrors presets.ts. */
+$themes: (
+  'hermes': (
+    bg: #041c1c, mid: #ffe6cb, accent: #34d399,
+    glow: rgba(255, 189, 56, 0.35), noise: 1, radius: 0.5rem,
+    base: 16px, lh: 1.6, light: false, font: null, mono: null
+  ),
+  'hermes-large': (
+    bg: #041c1c, mid: #ffe6cb, accent: #34d399,
+    glow: rgba(255, 189, 56, 0.35), noise: 1, radius: 0.5rem,
+    base: 18px, lh: 1.7, light: false, font: null, mono: null
+  ),
+  'midnight': (
+    bg: #0a0a1f, mid: #d4c8ff, accent: #a78bfa,
+    glow: rgba(167, 139, 250, 0.32), noise: 0.8, radius: 0.75rem,
+    base: 16px, lh: 1.6, light: false,
+    font: ('Inter', 'Microsoft Yahei', sans-serif),
+    mono: ('JetBrains Mono', monospace)
+  ),
+  'ember': (
+    bg: #1a0a06, mid: #ffd8b0, accent: #f97316,
+    glow: rgba(249, 115, 22, 0.38), noise: 1, radius: 0.25rem,
+    base: 16px, lh: 1.6, light: false,
+    font: ('Spectral', georgia, serif),
+    mono: ('IBM Plex Mono', monospace)
+  ),
+  'mono': (
+    bg: #0e0e0e, mid: #eaeaea, accent: #bdbdbd,
+    glow: rgba(255, 255, 255, 0.1), noise: 0.6, radius: 0,
+    base: 16px, lh: 1.6, light: false,
+    font: ('IBM Plex Sans', 'Microsoft Yahei', sans-serif),
+    mono: ('IBM Plex Mono', monospace)
+  ),
+  'cyberpunk': (
+    bg: #040608, mid: #9bffcf, accent: #00ff88,
+    glow: rgba(0, 255, 136, 0.22), noise: 1.2, radius: 0,
+    base: 16px, lh: 1.6, light: false,
+    font: ('Share Tech Mono', 'JetBrains Mono', monospace),
+    mono: ('Share Tech Mono', monospace)
+  ),
+  'rose': (
+    bg: #1a0f15, mid: #ffd4e1, accent: #f9a8d4,
+    glow: rgba(249, 168, 212, 0.3), noise: 0.9, radius: 1rem,
+    base: 16px, lh: 1.6, light: false,
+    font: ('Fraunces', georgia, serif),
+    mono: ('DM Mono', monospace)
+  ),
+  /* Authored directly in its post-inversion (on-screen) colors: a cream
+     canvas with vivid Nous-blue accents, per the source's documented
+     LENS_5I result. */
+  'nous-blue': (
+    bg: #e8f2fd, mid: #001934, accent: #0053fd,
+    glow: rgba(0, 83, 253, 0.1), noise: 0.25, radius: 0.5rem,
+    base: 16px, lh: 1.6, light: true, font: null, mono: null
+  )
+);
+
+/* Set every Chirpy variable for one theme from its four core tokens. */
+@mixin theme-vars($t) {
+  $bg: map.get($t, bg);
+  $mid: map.get($t, mid);
+  $accent: map.get($t, accent);
+  $glow: map.get($t, glow);
+  $noise: map.get($t, noise);
+  $radius: map.get($t, radius);
+  $base: map.get($t, base);
+  $lh: map.get($t, lh);
+  $light: map.get($t, light);
+  $font: map.get($t, font);
+  $mono: map.get($t, mono);
+
+  color-scheme: if($light, light, dark);
+  font-size: $base;
+
+  /* Tinted surfaces derived from bg ± mid. */
+  $panel: if($light, color.mix(#fff, $bg, 55%), color.mix($mid, $bg, 7%));
+  $panel-2: if($light, color.mix(#fff, $bg, 30%), color.mix($mid, $bg, 11%));
+  $panel-3: if($light, color.mix($mid, $bg, 6%), color.mix($mid, $bg, 16%));
+  $sink: if($light, color.mix($mid, $bg, 3%), color.mix(#000, $bg, 28%));
+  $code-bg: if($light, color.mix($mid, $bg, 5%), color.mix(#000, $bg, 45%));
+
+  /* Secondary accents (syntax + callouts) — tuned for dark vs light canvas. */
+  $blue: if($light, #0053fd, #6fb3ff);
+  $purple: if($light, #6d28d9, #b48bff);
+  $amber: if($light, #b45309, #ffbd38);
+  $rose: if($light, #be185d, #e08ba8);
+
+  /* Palette tokens consumed by the shared chrome. */
+  --hermes-cream: #{$mid};
+  --hermes-line: #{rgba($mid, 0.14)};
+  --hermes-line-strong: #{rgba($mid, 0.28)};
+  --hermes-teal: #{$accent};
+  --hermes-blue: #{$blue};
+  --hermes-purple: #{$purple};
+  --hermes-amber: #{$amber};
+  --hermes-rose: #{$rose};
+  --warm-glow: #{$glow};
+  --noise-opacity-mul: #{$noise};
+  --noise-blend: #{if($light, multiply, color-dodge)};
+  --glow-blend: #{if($light, multiply, lighten)};
+  --theme-radius: #{$radius};
+  --theme-lh: #{$lh};
+  @if $font != null {
+    --theme-font-sans: #{$font};
+  }
+  @if $mono != null {
+    --theme-font-mono: #{$mono};
+  }
+
+  /* Framework color */
+  --main-bg: #{$bg};
+  --mask-bg: #{$panel-2};
+  --main-border-color: var(--hermes-line);
+
+  /* Common color */
+  --text-color: #{rgba($mid, if($light, 0.9, 0.82))};
+  --text-muted-color: #{rgba($mid, if($light, 0.6, 0.5))};
+  --text-muted-highlight-color: #{rgba($mid, if($light, 0.78, 0.68))};
+  --heading-color: #{$mid};
+  --label-color: #{rgba($mid, if($light, 0.7, 0.6))};
+  --blockquote-border-color: var(--hermes-line-strong);
+  --blockquote-text-color: #{rgba($mid, if($light, 0.62, 0.55))};
+  --link-color: #{$accent};
+  --link-underline-color: #{rgba($accent, 0.45)};
+  --button-bg: #{$panel-2};
+  --btn-border-color: var(--hermes-line-strong);
+  --btn-backtotop-color: var(--hermes-cream);
+  --btn-backtotop-border-color: var(--hermes-line-strong);
+  --card-header-bg: #{$panel-2};
+  --checkbox-color: #{rgba($mid, 0.45)};
+  --checkbox-checked-color: var(--hermes-teal);
+  --img-bg: radial-gradient(
+    circle,
+    #{color.mix($mid, $bg, 4%)} 0%,
+    #{$bg} 100%
+  );
+  --shimmer-bg: linear-gradient(
+    90deg,
+    rgb(255 255 255 / 0%) 0%,
+    #{rgba($accent, 0.18)} 50%,
+    rgb(255 255 255 / 0%) 100%
+  );
+
+  /* Sidebar */
+  --site-title-color: var(--hermes-cream);
+  --site-subtitle-color: #{rgba($mid, 0.5)};
+  --sidebar-bg: #{$sink};
+  --sidebar-border-color: var(--hermes-line);
+  --sidebar-muted-color: #{rgba($mid, 0.48)};
+  --sidebar-active-color: var(--hermes-cream);
+  --sidebar-hover-bg: #{rgba($accent, 0.1)};
+  --sidebar-btn-bg: #{$panel-2};
+  --sidebar-btn-color: #{rgba($mid, 0.6)};
+  --avatar-border-color: #{rgba($mid, 0.55)};
+
+  /* Topbar */
+  --topbar-bg: #{rgba($bg, 0.72)};
+  --topbar-text-color: var(--text-color);
+  --search-border-color: var(--hermes-line-strong);
+  --search-icon-color: #{rgba($mid, 0.45)};
+  --input-focus-border-color: var(--hermes-teal);
+
+  /* Home page */
+  --post-list-text-color: #{rgba($mid, if($light, 0.82, 0.78))};
+  --btn-patinator-text-color: var(--text-color);
+  --btn-paginator-hover-color: #{$panel-3};
+
+  /* Posts */
+  --toc-highlight: var(--hermes-teal);
+  --toc-popup-border-color: var(--hermes-line-strong);
+  --tag-hover: #{rgba($accent, 0.18)};
+  --tb-odd-bg: #{$panel};
+  --tb-even-bg: #{color.mix($mid, $bg, 3%)};
+  --tb-border-color: var(--hermes-line);
+  --footnote-target-bg: #{rgba($accent, 0.3)};
+  --btn-share-color: #{rgba($mid, 0.55)};
+  --btn-share-hover-color: var(--hermes-cream);
+  --card-bg: #{$panel};
+  --card-hover-bg: #{$panel-3};
+  --card-shadow: rgb(0 0 0 / #{if($light, 12%, 56%)}) 0 6px 18px 0,
+    #{rgba($mid, 0.1)} 0 0 0 1px;
+  --kbd-wrap-color: var(--hermes-cream);
+  --kbd-text-color: var(--hermes-cream);
+  --kbd-bg-color: #{$panel-2};
+  --prompt-text-color: #{rgba($mid, 0.82)};
+  --prompt-tip-bg: #{rgba($accent, 0.14)};
+  --prompt-tip-icon-color: var(--hermes-teal);
+  --prompt-info-bg: #{rgba($blue, 0.12)};
+  --prompt-info-icon-color: var(--hermes-blue);
+  --prompt-warning-bg: #{rgba($amber, 0.14)};
+  --prompt-warning-icon-color: var(--hermes-amber);
+  --prompt-danger-bg: #{rgba($rose, 0.14)};
+  --prompt-danger-icon-color: var(--hermes-rose);
+
+  /* Tags */
+  --tag-border: var(--hermes-line-strong);
+  --tag-shadow: rgb(0 0 0 / 30%);
+  --dash-color: #{rgba($mid, 0.18)};
+  --search-tag-bg: #{$panel-2};
+
+  /* Categories */
+  --categories-border: var(--hermes-line);
+  --categories-hover-bg: #{$panel-3};
+  --categories-icon-hover-color: var(--hermes-cream);
+
+  /* Archive */
+  --timeline-node-bg: var(--hermes-teal);
+  --timeline-color: var(--hermes-line-strong);
+  --timeline-year-dot-color: var(--hermes-teal);
+
+  /* Code highlight */
+  --language-border-color: var(--hermes-line);
+  --highlight-bg-color: #{$code-bg};
+  --highlighter-rouge-color: var(--hermes-cream);
+  --highlight-lineno-color: #{rgba($mid, 0.38)};
+  --inline-code-bg: #{rgba($accent, 0.1)};
+  --code-color: #{rgba($mid, if($light, 0.9, 0.8))};
+  --code-header-text-color: #{rgba($mid, 0.5)};
+  --code-header-muted-color: #{$panel-3};
+  --code-header-icon-color: #{rgba($mid, 0.4)};
+  --clipboard-checked-color: var(--hermes-teal);
+  --filepath-text-color: var(--hermes-cream);
+
+  /* Chirpy shows different image variants per scheme. */
+  @if $light {
+    .dark {
+      display: none;
+    }
+  } @else {
+    .light {
+      display: none;
+    }
+  }
+}
+
+/* Shared chrome — reads the variables set above, emitted once for all themes. */
+@mixin chrome {
+  /* =====================================================================
+     Backdrop stack — copied from hermes-agent Backdrop.tsx (LENS_0).
+     ===================================================================== */
+
+  /* warm corner vignette */
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 9997;
+    pointer-events: none;
+    opacity: 0.22;
+    mix-blend-mode: var(--glow-blend, lighten);
+    background: radial-gradient(
+      ellipse at 0% 0%,
+      transparent 60%,
+      var(--warm-glow) 100%
+    );
+  }
+
+  /* film-grain noise (static texture — intentionally not gated on
+     reduced-motion, unlike the DS which gates its animated layer) */
+  body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 9998;
+    pointer-events: none;
+    opacity: calc(0.85 * var(--noise-opacity-mul, 1));
+    mix-blend-mode: var(--noise-blend, color-dodge);
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23eaeaea' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E");
+    background-size: 512px 512px;
+  }
+
+  /* ---- Typography personality ---- */
+  body {
+    font-family: var(--theme-font-sans, #{$chirpy-sans});
+    line-height: var(--theme-lh, 1.6);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5 {
+    font-family: var(--theme-font-sans, #{$chirpy-heading});
+    letter-spacing: 0.01em;
+  }
+
+  code,
+  kbd,
+  pre,
+  samp,
+  .highlight {
+    font-family: var(--theme-font-mono, #{$chirpy-mono});
+  }
+
+  /* ---- Corner-radius personality ---- */
+  .card,
+  .post-preview,
+  pre,
+  .highlight,
+  .highlighter-rouge,
+  img,
+  .preview-img,
+  #avatar,
+  blockquote.prompt-tip,
+  blockquote.prompt-info,
+  blockquote.prompt-warning,
+  blockquote.prompt-danger,
+  .post-tag,
+  #search-results .card {
+    border-radius: var(--theme-radius);
+  }
+
+  /* ---- Tags / chips: neon outline ---- */
+  .post-tag,
+  .tag {
+    border: 1px solid var(--hermes-line-strong) !important;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+
+    &:hover {
+      border-color: var(--hermes-teal) !important;
+      color: var(--hermes-teal) !important;
+      box-shadow: 0 0 8px var(--tag-hover);
+    }
+  }
+
+  /* ---- Sidebar toggle buttons glow on hover ---- */
+  #sidebar .sidebar-bottom .btn:hover,
+  #sidebar .sidebar-bottom a:hover {
+    color: var(--hermes-teal) !important;
+  }
+
+  /* ---- Categories ---- */
+  .categories.card,
+  .list-group-item {
+    background-color: var(--card-bg);
+  }
+
+  .categories {
+    .card-header {
+      background-color: var(--card-header-bg);
+    }
+
+    .list-group-item {
+      border-left: none;
+      border-right: none;
+      padding-left: 2rem;
+      border-color: var(--categories-border);
+
+      &:last-child {
+        border-bottom-color: var(--card-bg);
+      }
+    }
+  }
+
+  #archives li:nth-child(odd) {
+    background-image: linear-gradient(
+      to left,
+      var(--main-bg),
+      var(--card-bg),
+      var(--card-bg),
+      var(--card-bg),
+      var(--main-bg)
+    );
+  }
+
+  /* stylelint-disable-next-line selector-id-pattern */
+  #disqus_thread {
+    color-scheme: none;
+  }
+
+  /* --- Syntax highlight (base16-ish, recolored from theme accents) --- */
+  .highlight .gp {
+    color: var(--text-muted-color);
+  }
+
+  .highlight table td {
+    padding: 5px;
+  }
+
+  .highlight table pre {
+    margin: 0;
+  }
+
+  .highlight,
+  .highlight .w {
+    color: var(--code-color);
+    background-color: var(--highlight-bg-color);
+  }
+
+  .highlight .err {
+    color: var(--highlight-bg-color);
+    background-color: #ac4142;
+  }
+
+  .highlight .c,
+  .highlight .ch,
+  .highlight .cd,
+  .highlight .cm,
+  .highlight .cpf,
+  .highlight .c1,
+  .highlight .cs {
+    color: var(--text-muted-color);
+  }
+
+  .highlight .cp,
+  .highlight .nt,
+  .highlight .kc,
+  .highlight .kt,
+  .highlight .kd {
+    color: var(--hermes-amber);
+  }
+
+  .highlight .o,
+  .highlight .ow,
+  .highlight .p,
+  .highlight .pi {
+    color: var(--code-color);
+  }
+
+  .highlight .gi {
+    color: var(--hermes-teal);
+  }
+
+  .highlight .gd {
+    color: #f08a8b;
+    background-color: #320000;
+  }
+
+  .highlight .gh {
+    color: var(--hermes-blue);
+    background-color: var(--highlight-bg-color);
+    font-weight: bold;
+  }
+
+  .highlight .k,
+  .highlight .kn,
+  .highlight .kp,
+  .highlight .kr,
+  .highlight .kv {
+    color: var(--hermes-purple);
+  }
+
+  .highlight .s,
+  .highlight .sb,
+  .highlight .sc,
+  .highlight .dl,
+  .highlight .sd,
+  .highlight .s2,
+  .highlight .sh,
+  .highlight .sx,
+  .highlight .s1,
+  .highlight .m,
+  .highlight .mb,
+  .highlight .mf,
+  .highlight .mh,
+  .highlight .mi,
+  .highlight .il,
+  .highlight .mo,
+  .highlight .mx,
+  .highlight .ss {
+    color: var(--hermes-teal);
+  }
+
+  .highlight .sa {
+    color: var(--hermes-purple);
+  }
+
+  .highlight .sr {
+    color: #75b5aa;
+  }
+
+  .highlight .si,
+  .highlight .se {
+    color: #b76d45;
+  }
+
+  .highlight .nn,
+  .highlight .nc,
+  .highlight .no,
+  .highlight .na {
+    color: var(--hermes-amber);
+  }
+}
+
+/* Public entry point — call once at top level, after the light/dark blocks. */
+@mixin emit {
+  @each $name, $t in $themes {
+    html[data-theme='#{$name}'] {
+      @include theme-vars($t);
+    }
+  }
+
+  /* Build the grouped selector for the shared chrome. */
+  $sel: '';
+  @each $name, $t in $themes {
+    $piece: 'html[data-theme=#{$name}]';
+    $sel: if($sel == '', $piece, '#{$sel}, #{$piece}');
+  }
+
+  #{$sel} {
+    @include chrome;
+  }
+}


### PR DESCRIPTION
## 概述
移植 hermes-agent 仪表盘的全部视觉主题到博客,并新增一个下拉式主题选择器。

## 主题(9 个)
Hermes Teal(默认)/ Hermes Teal Large / Nous Blue(浅色)/ Midnight / Ember / Mono / Cyberpunk / Rosé,外加原 Chirpy 外观 "Classic"。

每个主题包含:
- 胶片噪点(`color-dodge` 噪点 SVG)+ 暖角光晕,逐主题强度/混合模式
- 专属强调色、圆角、字号、字体(按需注入 Google Fonts)
- 由四个核心色(背景/中景/强调/光晕)经 `color.mix` 推导出所有 Chirpy 变量

## 实现
- `_sass/themes/_hermes.scss`:数据驱动的 `$themes` map(加主题 = 加一行)
- 下拉选择器:`_data/themes.yml` + `_includes/theme-picker.html` + `_sass/components/_theme-picker.scss`,`position: fixed` 防侧边栏裁切
- `head.html` 内联脚本:早应用防闪烁、localStorage 持久化、字体注入、菜单交互
- 移除冗余的明暗切换按钮(选择器已涵盖)
- Projects 页卡片改为跟随主题(`--pj-*` 映射到主题变量)

## 验证
- 用 CDP 逐一截图 9 个主题 + 选择器菜单 + Projects 页(深色/浅色)均正常
- `npm run lint:scss` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)