### PR TITLE
fix(theme): 噪点减淡 ~30% + 主题选择器加宽防换行

### DIFF
--- a/_sass/components/_theme-picker.scss
+++ b/_sass/components/_theme-picker.scss
@@ -12,7 +12,7 @@
      left/bottom are set inline by the picker script on open. */
   position: fixed;
   z-index: 1051;
-  width: 16rem;
+  width: 19rem;
   max-width: calc(100vw - 1rem);
   max-height: 70vh;
   overflow-y: auto;
@@ -39,7 +39,7 @@
 .theme-option {
   display: flex;
   align-items: center;
-  gap: 0.7rem;
+  gap: 0.6rem;
   width: 100%;
   padding: 0.5rem 0.55rem;
   border: 0;
@@ -66,8 +66,8 @@
 .theme-swatch {
   display: inline-flex;
   flex: 0 0 auto;
-  width: 2.6rem;
-  height: 1.5rem;
+  width: 2.3rem;
+  height: 1.4rem;
   overflow: hidden;
   border-radius: 0.25rem;
   border: 1px solid var(--main-border-color);
@@ -94,8 +94,11 @@
 }
 
 .theme-option-desc {
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: var(--text-muted-color);
 }
 

--- a/_sass/themes/_hermes.scss
+++ b/_sass/themes/_hermes.scss
@@ -296,7 +296,7 @@ $themes: (
     inset: 0;
     z-index: 9998;
     pointer-events: none;
-    opacity: calc(0.85 * var(--noise-opacity-mul, 1));
+    opacity: calc(0.6 * var(--noise-opacity-mul, 1));
     mix-blend-mode: var(--noise-blend, color-dodge);
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23eaeaea' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E");
     background-size: 512px 512px;


### PR DESCRIPTION
- 噪点基础透明度 `0.85 → 0.6`(各主题 `--noise-opacity-mul` 不变),整体减少约 30%。
- 主题选择器菜单 `16rem → 19rem`,色卡/间距收紧、描述字号 `0.7→0.68rem`,「神名 · 诗句」描述全部单行显示,不再换行。

CDP 实测 `truncated: 0`;`npm run lint:scss` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)