### PR TITLE
fix(theme): 主题菜单按内容自适应宽度,去掉右侧空隙

### DIFF
--- a/_sass/components/_theme-picker.scss
+++ b/_sass/components/_theme-picker.scss
@@ -12,7 +12,12 @@
      left/bottom are set inline by the picker script on open. */
   position: fixed;
   z-index: 1051;
-  width: 19rem;
+
+  /* Hug the widest (single-line) row so the border sits close to the text
+     instead of leaving a wide empty gutter; the nowrap descriptions set the
+     width, clamped to the viewport. */
+  width: max-content;
+  min-width: 13rem;
   max-width: calc(100vw - 1rem);
   max-height: 70vh;
   overflow-y: auto;


### PR DESCRIPTION
把固定的 19rem 改成 `width: max-content`(min 13rem,封顶视口宽),菜单恰好与最长单行描述同宽——边框贴合文字,无空隙、无换行。CDP 实测宽度 252px、`wrap: 0`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)